### PR TITLE
Add rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "aws-config"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297b64446175a73987cedc3c438d79b2a654d0fff96f65ff530fbe039347644c"
+checksum = "48730d0b4c3d91c43d0d37168831d9fd0e065ad4a889a2ee9faf8d34c3d2804d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13dc54b4b49f8288532334bba8f87386a40571c47c37b1304979b556dc613c8"
+checksum = "c4ee6903f9d0197510eb6b44c4d86b493011d08b4992938f7b9be0333b6685aa"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -132,9 +132,32 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff4be07ef8185ee6de617e1af24da76cbc4532ceb45417d997cc33d169d3485"
+checksum = "12cc80036a6a3ce5a70359cfd94c5ccd3ecb0e4861a41d55d1c0b44fd814eacb"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssm"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d52af523b2356f49e4ae4f2c0b9f7fa0cb263e972ea71b3c9c2ea5679fa2e2a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -155,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019a07902c43b03167ea5df0182f0cb63fae89f9a9682c44d18cf2e4a042cb34"
+checksum = "b2be5ba83b077b67a6f7a1927eb6b212bf556e33bd74b5eaa5aa6e421910803a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -177,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c46ee08a48a7f4eaa4ad201dcc1dd537b49c50859d14d4510e00ad9d3f9af2"
+checksum = "022ca669825f841aef17b12d4354ef2b8651e4664be49f2d9ea13e4062a80c9f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -199,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f752ac730125ca6017f72f9db5ec1772c9ecc664f87aa7507a7d81b023c23713"
+checksum = "8e4a5f5cb007347c1ab34a6d56456301dfada921fc9e57d687ecb08baddd11ff"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -373,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbf2f3da841a8930f159163175cf6a3d16ddde517c1b0fba7aa776822800f40"
+checksum = "afb278e322f16f59630a83b6b2dc992a0b48aa74ed47b4130f193fae0053d713"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -590,6 +613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +626,19 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -687,12 +729,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -700,6 +768,34 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -714,15 +810,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -751,6 +859,26 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
 
 [[package]]
 name = "h2"
@@ -1137,6 +1265,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,10 +1512,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -1378,6 +1536,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1395,6 +1568,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -1403,6 +1588,18 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags 2.5.0",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1773,6 +1970,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2206,22 @@ name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tower_governor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3790eac6ad3fb8d9d96c2b040ae06e2517aa24b067545d1078b96ae72f7bb9a7"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http 1.1.0",
+ "pin-project",
+ "thiserror",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -2233,6 +2455,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-dynamodb",
+ "aws-sdk-ssm",
  "axum",
  "chrono",
  "chrono-tz",
@@ -2242,6 +2465,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tower_governor",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ anyhow = "1.0.81"
 tracing-subscriber = "0.3.18"
 reqwest = { version = "0.12.2", features = ["json"] }
 chrono-tz = "0.8.6"
-aws-config = { version = "1.1.9", features = ["behavior-version-latest"] }
-aws-sdk-dynamodb = "1.20.0"
+aws-config = { version = "1.1.10", features = ["behavior-version-latest"] }
+aws-sdk-dynamodb = "1.21.0"
 thiserror = "1.0.58"
 serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+1"] }
+tower_governor = "0.3.2"
+aws-sdk-ssm = "1.21.0"

--- a/pulumi-infra/index.ts
+++ b/pulumi-infra/index.ts
@@ -132,6 +132,9 @@ const ec2Instance = new aws.ec2.Instance("waterheater-calc-ec2-instance", {
   iamInstanceProfile: ecsInstanceProfile.name,
   userData: pulumi.interpolate`#!/bin/bash
     echo ECS_CLUSTER=${clusterName} >> /etc/ecs/ecs.config`,
+  metadataOptions: {
+    httpPutResponseHopLimit: 2,
+  },
   tags: {
     name: "waterheater-calc-ec2-instance",
   },
@@ -141,7 +144,7 @@ new awsx.ecs.EC2Service("waterheater-calc-ecs-ec2-service", {
   cluster: cluster.id,
   desiredCount: 1,
   deploymentMinimumHealthyPercent: 0,
-  deploymentMaximumPercent: 100,
+  deploymentMaximumPercent: 200,
   taskDefinition: taskDefinition.taskDefinition.arn,
 });
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use aws_sdk_dynamodb::operation::get_item::GetItemError;
+use aws_sdk_ssm::{error::SdkError, operation::get_parameters_by_path::GetParametersByPathError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -9,4 +10,6 @@ pub enum ApplicationError {
     Service(String),
     #[error("DynamoDB Put Item operation failed: {0}")]
     Database(#[from] Box<GetItemError>),
+    #[error("SSM Get Parameters operation failure: {0}")]
+    Ssm(#[from] SdkError<GetParametersByPathError>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,34 @@
-use axum::{extract::Path, http::StatusCode, response::IntoResponse, routing::get, Router};
+use std::{net::SocketAddr, time::Duration};
 
-use crate::service::is_water_heater_enabled_for_current_hour;
+use axum::{
+    extract::{ConnectInfo, Path},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use service::is_water_heater_enabled_for_current_hour;
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 
 mod db;
 mod error;
 mod service;
-
 mod tests;
 
 async fn handle_enable_water_heater(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Path((hours, starting_hour, ending_hour)): Path<(u32, u32, u32)>,
 ) -> impl IntoResponse {
-    if is_water_heater_enabled_for_current_hour(hours, starting_hour, ending_hour).await {
+    let is_enabled =
+        is_water_heater_enabled_for_current_hour(hours, starting_hour, ending_hour).await;
+
+    if is_enabled {
+        println!(
+            "Waterheater enabled at {} ({} hours starting at {})",
+            addr.ip(),
+            hours,
+            starting_hour
+        );
         return StatusCode::OK;
     }
 
@@ -22,16 +39,42 @@ async fn handle_enable_water_heater(
 async fn main() {
     tracing_subscriber::fmt::init();
 
+    // Allow bursts of five requests per IP
+    // Replenish one every two seconds
+    // Config needs to be Boxed as Axum reqires all layers to implement clone
+    let governor_conf = Box::new(
+        GovernorConfigBuilder::default()
+            .per_second(2)
+            .burst_size(5)
+            .finish()
+            .unwrap(),
+    );
+
+    let governor_limiter = governor_conf.limiter().clone();
+    let interval = Duration::from_secs(60);
+
+    std::thread::spawn(move || loop {
+        std::thread::sleep(interval);
+        governor_limiter.retain_recent();
+    });
+
     let app = Router::new()
-        // Health check on root path
         .route("/", get(StatusCode::OK))
         .route(
             "/waterheater/hours/:hours/starting/:starting_hour/ending/:ending_hour",
             get(handle_enable_water_heater),
-        );
+        )
+        .layer(GovernorLayer {
+            config: Box::leak(governor_conf),
+        });
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8001").await.unwrap();
     println!("Server Listening");
 
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .unwrap();
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,55 @@
+use std::sync::Mutex;
+
+use lazy_static::lazy_static;
+
+use crate::error::ApplicationError;
+
+lazy_static! {
+    static ref API_KEYS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+}
+
+async fn update_api_keys_cache(api_keys: Vec<String>) {
+    let mut api_keys_cache = API_KEYS.lock().unwrap();
+    *api_keys_cache = api_keys;
+}
+
+async fn cache_api_keys() -> Result<(), ApplicationError> {
+    match fetch_api_keys().await {
+        Ok(api_keys) => {
+            update_api_keys_cache(api_keys).await;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+async fn fetch_api_keys() -> Result<Vec<String>, ApplicationError> {
+    let config = aws_config::load_from_env().await;
+    let client = aws_sdk_ssm::Client::new(&config);
+
+    let mut next_token: Option<String> = None;
+    let mut api_keys: Vec<String> = Vec::new();
+
+    loop {
+        let resp = client
+            .get_parameters_by_path()
+            .path("/waterheater_calc/api_keys/")
+            .recursive(true)
+            .with_decryption(true)
+            .set_next_token(next_token)
+            .send()
+            .await?;
+
+        resp.parameters()
+            .iter()
+            .for_each(|param| api_keys.push(param.value().unwrap().to_string()));
+
+        if resp.next_token().is_none() {
+            break;
+        }
+
+        next_token = resp.next_token().map(|t| t.to_string());
+    }
+
+    Ok(api_keys)
+}

--- a/src/tests/service_tests.rs
+++ b/src/tests/service_tests.rs
@@ -27,6 +27,15 @@ fn create_pricing_with_hour(hour: u32, price: f32) -> Pricing {
     }
 }
 
+fn create_pricing_with_hour_and_day(hour: u32, day: u32, price: f32) -> Pricing {
+    let offset = FixedOffset::east_opt(0).unwrap();
+    let date_time = offset.with_ymd_and_hms(2024, 4, day, hour, 0, 0).unwrap();
+    Pricing {
+        date_time,
+        price_no_tax: price,
+    }
+}
+
 #[test]
 fn test_get_filtered_pricing_normal_period() {
     let pricing_data = vec![
@@ -54,15 +63,18 @@ fn test_get_filtered_pricing_cross_midnight() {
         create_static_pricing_with_hour(3),
         create_static_pricing_with_hour(4),
         create_static_pricing_with_hour(5),
+        create_static_pricing_with_hour(6),
+        create_static_pricing_with_hour(7),
+        create_static_pricing_with_hour(8),
     ];
     let pricing = Arc::from(pricing_data.into_boxed_slice());
     let starting_hour = 22;
-    let ending_hour = 5;
+    let ending_hour = 7;
 
     let filtered_pricing = get_filtered_pricing(&pricing, &starting_hour, &ending_hour);
-    assert_eq!(filtered_pricing.len(), 7);
+    assert_eq!(filtered_pricing.len(), 9);
     assert_eq!(filtered_pricing[0].date_time.hour(), 22);
-    assert!(filtered_pricing.iter().any(|&p| p.date_time.hour() == 2));
+    assert_eq!(filtered_pricing.last().unwrap().date_time.hour(), 6);
 }
 
 #[test]
@@ -96,16 +108,15 @@ fn test_calculate_cheapest_start_time() {
 #[test]
 fn test_calculate_cheapest_start_time_before_midnight() {
     let pricing_data = vec![
-        create_pricing_with_hour(22, 0.01),
-        create_pricing_with_hour(23, 0.02),
-        create_pricing_with_hour(0, 0.004),
-        create_pricing_with_hour(1, 0.1),
-        create_pricing_with_hour(2, 0.2),
-        create_pricing_with_hour(3, 0.6),
-        create_pricing_with_hour(4, 0.7),
-        create_pricing_with_hour(5, 0.8),
-        create_pricing_with_hour(6, 0.9),
-        create_pricing_with_hour(7, 0.6),
+        create_pricing_with_hour_and_day(22, 9, 4.722),
+        create_pricing_with_hour_and_day(23, 9, 4.078),
+        create_pricing_with_hour_and_day(0, 10, 0.619),
+        create_pricing_with_hour_and_day(1, 10, 0.869),
+        create_pricing_with_hour_and_day(2, 10, 0.508),
+        create_pricing_with_hour_and_day(3, 10, 0.107),
+        create_pricing_with_hour_and_day(4, 10, 0.000),
+        create_pricing_with_hour_and_day(5, 10, -0.001),
+        create_pricing_with_hour_and_day(6, 10, 0.000),
     ];
     let pricing_refs: Vec<&Pricing> = pricing_data.iter().collect();
 
@@ -116,7 +127,7 @@ fn test_calculate_cheapest_start_time_before_midnight() {
         Some(
             FixedOffset::east_opt(0)
                 .unwrap()
-                .with_ymd_and_hms(2024, 4, 8, 22, 0, 0)
+                .with_ymd_and_hms(2024, 4, 10, 1, 0, 0)
                 .unwrap()
         )
     );

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -36,7 +36,6 @@ struct HourlyPrice(DateTime<Tz>, f32);
 
 async fn get_electricity_pricing() -> Result<EnergyChartApiResponse, reqwest::Error> {
     let start_date = Helsinki.from_utc_datetime(&chrono::Utc::now().naive_utc());
-    println!("start_date: {}", start_date);
     let end_date = match start_date.checked_add_days(Days::new(1)) {
         Some(d) => d,
         None => start_date,


### PR DESCRIPTION
[Add rate limiting using tower-governor crate](https://github.com/jyrihogman/waterheater-laskuri/commit/04f797d32aa7460a44d820df7f23740310f2a4b7)
Allow bursts of 5 requests and replenish every two seconds

[Improve tests](https://github.com/jyrihogman/waterheater-laskuri/commit/63892737d2b3ae1bf550fb79eef0a0796b670c63)

[Update dependencies and add Parameter Store integration](https://github.com/jyrihogman/waterheater-laskuri/commit/a4e1e16666f0cdf0b40d161f48a201b129f33077)
Left unused for now!

[Quick refactoring](https://github.com/jyrihogman/waterheater-laskuri/commit/a6d05db35189d19c8054b4d0bcee29fa2fdbba94)

[Add httPutResponseHopLimit for the EC2 instance](https://github.com/jyrihogman/waterheater-laskuri/commit/63fd805b47365d2c91a4095cb60fbb9c8272989e)

Instance metadata service limits the number of hops a request can make,
and with the AWS SDK & Dynamo update the dynamo client uses IMDsv2,
which limits the number of hops to 1. With this creating a dynamo db client
would time out, I assume there is an extra hop due to the Docker container.

Setting the httpPutResponseHopLimit to 2 resolves the issue.
